### PR TITLE
Suppress the warnings reported by cppcheck

### DIFF
--- a/tests.c
+++ b/tests.c
@@ -89,7 +89,7 @@ int test_bitCount(int x)
     int result = 0;
     int i;
     for (i = 0; i < 32; i++)
-        result += (x >> i) & 0x1;
+        result += ((unsigned) x >> i) & 0x1;
     return result;
 }
 
@@ -107,9 +107,9 @@ int test_bitMatch(int x, int y)
     int i;
     int result = 0;
     for (i = 0; i < 32; i++) {
-        int mask = 1 << i;
+        int mask = 1u << i;
         int bit = (x & mask) == (y & mask);
-        result |= bit << i;
+        result |= (unsigned) bit << i;
     }
     return result;
 }
@@ -129,7 +129,7 @@ int test_bitParity(int x)
     int result = 0;
     int i;
     for (i = 0; i < 32; i++)
-        result ^= (x >> i) & 0x1;
+        result ^= ((unsigned) x >> i) & 0x1;
     return result;
 }
 
@@ -138,7 +138,7 @@ int test_bitReverse(int x)
     int result = 0;
     int i;
     for (i = 0; i < 32; i++) {
-        int bit = (x >> i) & 0x1;
+        int bit = ((unsigned) x >> i) & 0x1;
         int pos = 31 - i;
         result |= bit << pos;
     }
@@ -404,7 +404,7 @@ int test_getByte(int x, int n)
 
 int test_greatestBitPos(int x)
 {
-    unsigned mask = 1 << 31;
+    unsigned mask = 1u << 31;
     if (x == 0)
         return 0;
     while (!(mask & x)) {
@@ -433,7 +433,7 @@ int test_intLog2(int x)
     int mask, result;
     /* find the leftmost bit */
     result = 31;
-    mask = 1 << result;
+    mask = 1u << result;
     while (!(x & mask)) {
         result--;
         mask = 1 << result;
@@ -548,7 +548,7 @@ int test_leftBitCount(int x)
     int result = 0;
     int i;
     for (i = 31; i >= 0; i--) {
-        int bit = (x >> i) & 0x1;
+        int bit = ((unsigned) x >> i) & 0x1;
         if (!bit)
             break;
         result++;
@@ -734,7 +734,7 @@ int test_twosComp2SignMag(int x)
 {
     int sign = x < 0;
     int mag = x < 0 ? -x : x;
-    return (sign << 31) | mag;
+    return ((unsigned) sign << 31) | mag;
 }
 
 int test_upperBits(int x)


### PR DESCRIPTION
Because cppcheck will complain when shifting signed 32-bit
value by 31 bits, this commit change these variables that
needs to shift 31 bits to become unsigned and add the
integer-suffix 'u' to integer constants.
For example:
`x >> 31` becomes `(unsigned) x >> 31`
`1 >> 31` becomes `1u >> 31`